### PR TITLE
Expose VNC endpoint and enable cross origin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ ENV/
 
 # Logs
 *.log
+
+# Node.js
+node_modules/
+computer-use-demo/node_modules/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The project also includes a simple WebSocket echo endpoint at `/ws`.
 ## Using with Anthropic Quickstarts
 
 This backend can be paired with the [Anthropic Quickstarts Computer Use Demo](https://github.com/anthropics/anthropic-quickstarts/tree/main/computer-use-demo).
+For convenience a `computer-use-demo` directory is included in this repository; populate it with the quickstart frontend by copying the files from the upstream project.
 Run this API server and then start the quickstart front end. The front end will
 communicate with the endpoints above and use `/sessions/{id}/vnc` to retrieve
 the VNC connection URL.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ This will start the API server on `http://localhost:8000`.
 - `GET /sessions` – list all sessions.
 - `POST /sessions/{session_id}/messages` – add a message to a session.
 - `GET /sessions/{session_id}/messages` – retrieve all messages for a session.
+- `GET /sessions/{session_id}/vnc` – obtain a VNC URL for the session.
 
 The project also includes a simple WebSocket echo endpoint at `/ws`.
+
+## Using with Anthropic Quickstarts
+
+This backend can be paired with the [Anthropic Quickstarts Computer Use Demo](https://github.com/anthropics/anthropic-quickstarts/tree/main/computer-use-demo).
+Run this API server and then start the quickstart front end. The front end will
+communicate with the endpoints above and use `/sessions/{id}/vnc` to retrieve
+the VNC connection URL.
 

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,5 +1,13 @@
 from fastapi import APIRouter
-from .routes import router as api_router
+
+from .routes import router as routes_router
+from .websockets import router as websockets_router
+
+# Combine HTTP and WebSocket routes into a single router that the main
+# FastAPI application can include.
+api_router = APIRouter()
+api_router.include_router(routes_router)
+api_router.include_router(websockets_router)
 
 __all__ = ["api_router", "APIRouter"]
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -6,6 +6,7 @@ from app.db import models
 from app.db.database import get_db
 from app.schemas.message import Message, MessageCreate
 from app.schemas.session import Session as SessionSchema
+from app.services.vnc_service import get_vnc_url
 
 router = APIRouter()
 
@@ -44,4 +45,13 @@ def get_messages(session_id: int, db: Session = Depends(get_db)):
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
     return session.messages
+
+
+@router.get("/sessions/{session_id}/vnc")
+def get_vnc(session_id: int, db: Session = Depends(get_db)):
+    """Return a VNC connection URL for the given session."""
+    session = db.query(models.Session).filter(models.Session.id == session_id).first()
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return {"url": get_vnc_url(session_id)}
 

--- a/computer-use-demo/README.md
+++ b/computer-use-demo/README.md
@@ -1,0 +1,18 @@
+# Computer Use Demo
+
+This directory is intended to contain the [Anthropic Quickstarts Computer Use Demo](https://github.com/anthropics/anthropic-quickstarts/tree/main/computer-use-demo) frontend. Due to network restrictions in the development environment, the files were not automatically fetched.
+
+To set it up locally, run:
+
+```bash
+git clone https://github.com/anthropics/anthropic-quickstarts.git
+cp -r anthropic-quickstarts/computer-use-demo/* ./computer-use-demo/
+```
+
+Then install dependencies and run the frontend:
+
+```bash
+cd computer-use-demo
+npm install
+npm run dev
+```

--- a/main.py
+++ b/main.py
@@ -1,10 +1,22 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.api import api_router
 from app.db import init_db
 
 
 app = FastAPI()
+
+# Allow cross-origin requests so the quickstart front end can
+# communicate with this backend when running on a different host/port.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 init_db()
 app.include_router(api_router)
 


### PR DESCRIPTION
## Summary
- enable CORS so the quickstart front end can talk to the backend
- serve HTTP and WebSocket routes from a unified router
- add endpoint to fetch session VNC URL and document quickstart usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d80f2694483258c4e7c5836521b35